### PR TITLE
Eslint project setting

### DIFF
--- a/apps/next/eslint.config.cjs
+++ b/apps/next/eslint.config.cjs
@@ -6,13 +6,4 @@ module.exports = [
   },
   // Use the Next.js configuration directly
   ...nextjsConfig,
-  // Override for specific project settings
-  {
-    files: ["**/*.ts", "**/*.tsx"],
-    languageOptions: {
-      parserOptions: {
-        project: "./tsconfig.json",
-      },
-    },
-  },
 ]

--- a/apps/tauri/eslint.config.cjs
+++ b/apps/tauri/eslint.config.cjs
@@ -12,13 +12,4 @@ module.exports = [
   },
   // Use the React configuration
   reactConfig,
-  // Override for specific project settings
-  {
-    files: ["**/*.ts", "**/*.tsx"],
-    languageOptions: {
-      parserOptions: {
-        project: "./tsconfig.json",
-      },
-    },
-  },
 ]

--- a/packages/ai/eslint.config.js
+++ b/packages/ai/eslint.config.js
@@ -18,16 +18,12 @@ module.exports = [
       },
     },
   },
-  // TypeScript files - use full node config with project
+  // TypeScript files - use full node config
   {
     files: ["**/*.ts", "**/*.tsx"],
     ...nodeConfig,
     languageOptions: {
       ...nodeConfig.languageOptions,
-      parserOptions: {
-        ...nodeConfig.languageOptions.parserOptions,
-        project: "./tsconfig.json",
-      },
     },
   },
 ]

--- a/packages/auth/eslint.config.js
+++ b/packages/auth/eslint.config.js
@@ -18,16 +18,12 @@ module.exports = [
       },
     },
   },
-  // TypeScript files - use full node config with project
+  // TypeScript files - use full node config
   {
     files: ["**/*.ts", "**/*.tsx"],
     ...nodeConfig,
     languageOptions: {
       ...nodeConfig.languageOptions,
-      parserOptions: {
-        ...nodeConfig.languageOptions.parserOptions,
-        project: "./tsconfig.json",
-      },
     },
   },
 ]

--- a/packages/components/eslint.config.js
+++ b/packages/components/eslint.config.js
@@ -19,7 +19,7 @@ module.exports = [
       },
     },
   },
-  // TypeScript files - use full react config with project
+  // TypeScript files - use full react config
   {
     files: ["**/*.ts", "**/*.tsx"],
     ...reactConfig,
@@ -29,10 +29,6 @@ module.exports = [
         ...reactConfig.languageOptions.globals,
         // Add process for environment variables
         process: "readonly",
-      },
-      parserOptions: {
-        ...reactConfig.languageOptions.parserOptions,
-        project: "./tsconfig.json",
       },
     },
   },

--- a/packages/database/eslint.config.js
+++ b/packages/database/eslint.config.js
@@ -18,16 +18,12 @@ module.exports = [
       },
     },
   },
-  // TypeScript files - use full node config with project
+  // TypeScript files - use full node config
   {
     files: ["**/*.ts", "**/*.tsx"],
     ...nodeConfig,
     languageOptions: {
       ...nodeConfig.languageOptions,
-      parserOptions: {
-        ...nodeConfig.languageOptions.parserOptions,
-        project: "./tsconfig.json",
-      },
     },
   },
 ]

--- a/packages/emails/eslint.config.js
+++ b/packages/emails/eslint.config.js
@@ -12,14 +12,4 @@ module.exports = [
   },
   // Use the React configuration
   reactConfig,
-  // Override for specific project settings
-  {
-    files: ["**/*.ts", "**/*.tsx"],
-    languageOptions: {
-      parserOptions: {
-        project: "./tsconfig.json",
-        tsconfigRootDir: __dirname,
-      },
-    },
-  },
 ]

--- a/packages/hooks/eslint.config.js
+++ b/packages/hooks/eslint.config.js
@@ -12,13 +12,4 @@ module.exports = [
   },
   // Use the React configuration
   reactConfig,
-  // Override for specific project settings
-  {
-    files: ["**/*.ts", "**/*.tsx"],
-    languageOptions: {
-      parserOptions: {
-        project: "./tsconfig.json",
-      },
-    },
-  },
 ]

--- a/packages/hooks/src/boards.ts
+++ b/packages/hooks/src/boards.ts
@@ -44,7 +44,7 @@ export const useDeleteBoardCard = (
           queryClient.setQueryData<Note | undefined>(
             trpc.notes.getNote.queryKey({ id: variables.noteId }),
             (old) => {
-              if (!old || old.note.type !== "board") return old
+              if (old?.note.type !== "board") return old
 
               return {
                 ...old,
@@ -129,7 +129,7 @@ export const useMoveBoardCard = (
           queryClient.setQueryData<Note | undefined>(
             trpc.notes.getNote.queryKey({ id: variables.noteId }),
             (old) => {
-              if (!old || old.note.type !== "board") return old
+              if (old?.note.type !== "board") return old
 
               // Find the card to move first
               let cardToMove:
@@ -272,7 +272,7 @@ export const useReorderBoardColumns = (
           queryClient.setQueryData<Note | undefined>(
             trpc.notes.getNote.queryKey({ id: variables.noteId }),
             (old) => {
-              if (!old || old.note.type !== "board") return old
+              if (old?.note.type !== "board") return old
 
               const columns = [...old.note.content.columns]
               const sourceIdx = variables.sourceIndex
@@ -363,7 +363,7 @@ export const useUpdateBoardCardTitle = (
           queryClient.setQueryData<Note | undefined>(
             trpc.notes.getNote.queryKey({ id: variables.noteId }),
             (old) => {
-              if (!old || old.note.type !== "board") return old
+              if (old?.note.type !== "board") return old
 
               return {
                 ...old,
@@ -452,7 +452,7 @@ export const useUpdateBoardCardContent = (
           queryClient.setQueryData<Note | undefined>(
             trpc.notes.getNote.queryKey({ id: variables.noteId }),
             (old) => {
-              if (!old || old.note.type !== "board") return old
+              if (old?.note.type !== "board") return old
 
               return {
                 ...old,
@@ -541,7 +541,7 @@ export const useAddBoardCard = (
           queryClient.setQueryData<Note | undefined>(
             trpc.notes.getNote.queryKey({ id: variables.noteId }),
             (old) => {
-              if (!old || old.note.type !== "board") return old
+              if (old?.note.type !== "board") return old
 
               return {
                 ...old,
@@ -638,7 +638,7 @@ export const useDeleteBoardColumn = (
           queryClient.setQueryData<Note | undefined>(
             trpc.notes.getNote.queryKey({ id: variables.noteId }),
             (old) => {
-              if (!old || old.note.type !== "board") return old
+              if (old?.note.type !== "board") return old
 
               return {
                 ...old,
@@ -722,7 +722,7 @@ export const useUpdateBoardColumn = (
           queryClient.setQueryData<Note | undefined>(
             trpc.notes.getNote.queryKey({ id: variables.noteId }),
             (old) => {
-              if (!old || old.note.type !== "board") return old
+              if (old?.note.type !== "board") return old
 
               return {
                 ...old,
@@ -816,7 +816,7 @@ export const useAddBoardColumn = (
           queryClient.setQueryData<Note | undefined>(
             trpc.notes.getNote.queryKey({ id: variables.noteId }),
             (old) => {
-              if (!old || old.note.type !== "board") return old
+              if (old?.note.type !== "board") return old
 
               return {
                 ...old,

--- a/packages/lib/eslint.config.js
+++ b/packages/lib/eslint.config.js
@@ -19,7 +19,7 @@ module.exports = [
       },
     },
   },
-  // TypeScript files - use node config with project
+  // TypeScript files - use node config
   {
     files: ["**/*.ts", "**/*.tsx"],
     ...nodeConfig,
@@ -28,10 +28,6 @@ module.exports = [
       globals: {
         ...nodeConfig.languageOptions.globals,
         ...globals.browser,
-      },
-      parserOptions: {
-        ...nodeConfig.languageOptions?.parserOptions,
-        project: "./tsconfig.json",
       },
     },
   },

--- a/packages/posthog/eslint.config.js
+++ b/packages/posthog/eslint.config.js
@@ -12,13 +12,4 @@ module.exports = [
   },
   // Use the React configuration
   reactConfig,
-  // Override for specific project settings
-  {
-    files: ["**/*.ts", "**/*.tsx"],
-    languageOptions: {
-      parserOptions: {
-        project: "./tsconfig.json",
-      },
-    },
-  },
 ]

--- a/packages/trpc/eslint.config.js
+++ b/packages/trpc/eslint.config.js
@@ -18,16 +18,12 @@ module.exports = [
       },
     },
   },
-  // TypeScript files - use full node config with project
+  // TypeScript files - use full node config
   {
     files: ["**/*.ts", "**/*.tsx"],
     ...nodeConfig,
     languageOptions: {
       ...nodeConfig.languageOptions,
-      parserOptions: {
-        ...nodeConfig.languageOptions.parserOptions,
-        project: "./tsconfig.json",
-      },
     },
   },
 ]


### PR DESCRIPTION
Remove conflicting `parserOptions.project` settings from ESLint configs to resolve parsing errors.

The `@ignita/eslint` shared configuration enables `parserOptions.projectService: true`. However, several individual package and app `eslint.config.*` files were also explicitly setting `parserOptions.project`. This combination causes a "Parsing error: Enabling 'project' does nothing when 'projectService' is enabled" error with `typescript-eslint`. This PR removes the redundant `parserOptions.project` settings, allowing all configurations to consistently inherit `projectService` from the shared base.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-17263180-f1f1-4616-9a0f-d7bc56997c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-17263180-f1f1-4616-9a0f-d7bc56997c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

